### PR TITLE
Missing ilibpq in libs returned by pg_config in 9.6. It was compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MODULES	= $(patsubst %.c,%,$(wildcard src/*.c))
 MODULE_big = $(EXTENSION)
 OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 PG_CPPFLAGS= $(shell $(PG_CONFIG) --cflags ) -I $(shell $(PG_CONFIG) --includedir)
-SHLIB_LINK = $(shell $(PG_CONFIG) --libs )
+SHLIB_LINK = $(shell $(PG_CONFIG) --libs )  -lpq
 
 PG94 = $(shell $(PG_CONFIG) --version | egrep " 8\.| 9\.0| 9\.1| 9\.2| 9\.3" > /dev/null && echo no || echo yes)
 ifeq ($(PG94),no)


### PR DESCRIPTION
but refusing to install due to missing libpq symbols.